### PR TITLE
Fix: Import CardFooter in create post page

### DIFF
--- a/src/app/news/create/page.tsx
+++ b/src/app/news/create/page.tsx
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { FilePlus2, Edit } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { mockClubs } from "@/lib/mock-data"; // Assuming club leads create posts for their clubs


### PR DESCRIPTION
The CardFooter component was used in `src/app/news/create/page.tsx` but not imported, causing a ReferenceError during the Netlify build.

This commit adds CardFooter to the import statement from "@/components/ui/card" in the aforementioned file, resolving the build error.